### PR TITLE
Lower PHP requirement, remove ext-mssql conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,8 @@
     "name": "hexblot/mssql-compat",
     "description": "Small wrapper for PDO that emulates the deprecated mssql_* functions, and allows legacy software to work in PHP7+",
     "require": {
-        "php": ">=7.0.0",
+        "php": ">=5.3",
         "ext-pdo": "*"
-    },
-    "conflict": {
-        "ext-mssql": "*"
     },
     "suggest": {
         "ext-pdo_dblib": "*"


### PR DESCRIPTION
* The library should work on much older versions of PHP
* The library doesn't conflict with the mssql extension because the entire
  file is wrapped in the following if statement:

      if(!function_exists('mssql_connect')) {

* This will allow people running on PHP5 to include this compatibility
  library prior to upgrading their systems to PHP7, otherwise Composer
  complains with the following:

      Package hexblot/mssql-compat at version  has a PHP requirement incompatible with your PHP version