### PR TITLE
Add global declaration before assignment

### DIFF
--- a/mssql_compat.php
+++ b/mssql_compat.php
@@ -8,6 +8,7 @@ if(!function_exists('mssql_connect')) {
   define('MSSQL_BOTH',  PDO::FETCH_BOTH );
 
   // Unfortunately MSSQL function assume too much, hence the need for pesky globals.
+  global $mssql_compat_metadata;
   $mssql_compat_metadata  = array(
     'last_key'   => '',
     'last_error' => '',


### PR DESCRIPTION
The '$mssql_compat_metadata' global was not being used properly in the
different functions when it was assigned before being declared global.